### PR TITLE
Modified order_controller_decorator to prevent "missing tamplate" error

### DIFF
--- a/app/controllers/orders_controller_decorator.rb
+++ b/app/controllers/orders_controller_decorator.rb
@@ -10,7 +10,7 @@ OrdersController.class_eval do
         redirect_to cart_path
       end
     else
-      render :edit
+      render :edit unless request.xhr?
     end
   end
   


### PR DESCRIPTION
500 error appears when we put non numeric value in quantity fields
