### PR TITLE
Fix to properly handle requests when JS is disabled

### DIFF
--- a/app/controllers/orders_controller_decorator.rb
+++ b/app/controllers/orders_controller_decorator.rb
@@ -3,8 +3,7 @@ OrdersController.class_eval do
   
   def update
     @order = current_order
-    if @order.update_attributes(params[:order])
-      @order.line_items = @order.line_items.select {|li| li.quantity > 0 }
+    if @order.update_attributes(params[:order]) and (@order.line_items = @order.line_items.select {|li| li.quantity > 0 }).present?
       if request.xhr?
         @order.update!
       else

--- a/app/views/orders/_advanced_cart.html.erb
+++ b/app/views/orders/_advanced_cart.html.erb
@@ -23,6 +23,7 @@
         <%= order_form.text_field :coupon_code, :size => 19 %>
         <span class="ajax_loader"><%= image_tag 'ajax_loader.gif', :alt => t('loading') %></span>
         <%= order_form.submit t("apply") %>
+        <span id="updating_cart_please_wait"></span>
       </div>
     <% end %>
 

--- a/app/views/orders/update.js.erb
+++ b/app/views/orders/update.js.erb
@@ -1,2 +1,6 @@
-$("#advanced_cart").html("<%= escape_javascript(render('advanced_cart')) %>");
-
+<% if @order.line_items.present? %>
+  $("#advanced_cart").html("<%= escape_javascript(render('advanced_cart')) %>");
+<% else %>
+  $("#updating_cart_please_wait").html("<span class='flash notice'>Please wait while we update your cart...</span>");
+  window.location.reload(true);
+<% end %>


### PR DESCRIPTION
When JS is disabled an ActionView::MissingTemplate error is thrown because of the `.js.erb` extension on the `estimate_shipping_costs` view.  This fix uses a `respond_with` block to respond correctly based on format.

For HTML the user is redirected to `cart_path` with a flash indicating the estimated shipping costs.  For JS, nothing changes.
